### PR TITLE
chore: test wasn't running anymore in the pipeline

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 scripts/cron-jobs/dependencies/node_modules
+src/www/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
   email: false
 script:
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then commitlint-travis; fi
+  - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then yarn test; fi
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then yarn generate:man; fi
   - if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then yarn generate:ghpage; fi
   - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then yarn monitor; fi


### PR DESCRIPTION
- now it should work codecov
- ignore dist folder if not eslint will fail
- related issue #32