### PR TITLE
docs: fix wrong url and readme license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JSON-Analyzer
 [![Build Status](https://travis-ci.org/Fetz/json-analyzer.svg?branch=master)](https://travis-ci.org/Fetz/json-analyzer) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Fetz/json-analyzer/blob/master/LICENSE) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier) [![codecov](https://codecov.io/gh/Fetz/json-analyzer/branch/master/graph/badge.svg)](https://codecov.io/gh/Fetz/json-analyzer) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FFetz%2Fjson-analyzer.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FFetz%2Fjson-analyzer?ref=badge_shield) [![Known Vulnerabilities](https://snyk.io/test/github/Fetz/json-analyzer/badge.svg)](https://snyk.io/test/github/Fetz/json-analyzer)
 
-###### [TRY ONLINE](https://fetz.github.io/json-analyzer/#try-online) | [CLI](#using-in-the-command-line) | [BROWSER/NODE](using-in-the-nodebrowser-environment)
+###### [TRY ONLINE](https://fetz.github.io/json-analyzer/#try-online) | [CLI](#using-in-the-command-line) | [BROWSER/NODE](#using-in-the-nodebrowser-environment)
 
 > Analyze and measure where you should spend your time optimizing your JSON files or REST APIs.
 > Use it either in our [online demo](https://fetz.github.io/json-analyzer/#try-online), [command line](#using-in-the-command-line) or in your [node/browser](#using-in-the-nodebrowser-environment) project.
@@ -96,7 +96,7 @@ console.log(
 
 ## License
 
-This project is licensed under the MIT license, Copyright (c) 2017 Fetz. For more information see [LICENSE](./LICENSE)
+This project is licensed under the MIT license, Copyright (c) 2018 Luis Silva. For more information see [LICENSE](./LICENSE)
 
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FFetz%2Fjson-analyzer.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FFetz%2Fjson-analyzer?ref=badge_large)


### PR DESCRIPTION
- wrong url in the header url 
- license needs to be matching the one generated by github